### PR TITLE
Feat/#41

### DIFF
--- a/src/main/java/cmc/controller/UserController.java
+++ b/src/main/java/cmc/controller/UserController.java
@@ -22,7 +22,11 @@ public class UserController {
 
     // 회원 탈퇴
     @DeleteMapping("/api/v1/user")
-    public ResponseEntity<ApiResponse> deleteUser() {
+    public ResponseEntity<ApiResponse> deleteUser(Principal principal) {
+
+        Long tokenUserId = Long.parseLong(principal.getName());
+
+        userService.deleteUser(tokenUserId);
 
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse(ResponseCode.USER_DELETE_SUCCESS));
     }

--- a/src/main/java/cmc/domain/Avatar.java
+++ b/src/main/java/cmc/domain/Avatar.java
@@ -4,6 +4,8 @@ import cmc.common.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Table(name = "Avatar", indexes = {@Index(columnList = "userId")})
@@ -29,6 +31,9 @@ public class Avatar extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "userId")
     private User user;
+
+    @OneToMany(targetEntity = WorldAvatar.class, fetch = FetchType.LAZY, mappedBy = "avatar", cascade = CascadeType.ALL)
+    private List<WorldAvatar> worldAvatars = new ArrayList<>();
 
     @Builder
     public Avatar(Long avatarId, String avatarName, String avatarMessage, String avatarImg, User user) {

--- a/src/main/java/cmc/service/UserService.java
+++ b/src/main/java/cmc/service/UserService.java
@@ -56,6 +56,10 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+    public void deleteUser(Long userId) {
+        userRepository.deleteById(userId);
+    }
+
     private void checkDuplicatedBlock(Long blockingUserId, Long blockedUserId) {
         if(!userBlockRepository.findBlockByBlockingUserIdAndBlockedUserId(blockingUserId, blockedUserId).isEmpty()){
             throw new BusinessException(ErrorCode.DUPLICATED_BLOCK);


### PR DESCRIPTION
## 📌 관련 이슈
closes #41 
## ✨ 작업 내용
- 회원 탈퇴 api 구현
- 회원이 탈퇴될때 자식 엔티티들인 avatar가 삭제됨. 이때 avatar와 fk를 맺고 있는 worldavatar 때문에 delete가 안되는 이슈가 발생하여 양방향 매핑 후 cascade type ALL 를 설정해둠
## 📚 기타
