### PR TITLE
[Fix] 만료 세계관 제외, 세계관 조회 중복 문제 수정

### DIFF
--- a/src/main/java/cmc/controller/WorldController.java
+++ b/src/main/java/cmc/controller/WorldController.java
@@ -73,13 +73,13 @@ public class WorldController {
     }
 
     @Operation(
-            summary = "세계관 최신순 조회",
-            description = "세계관을 최신순으로 조회합니다." +
+            summary = "세계관 전체 조회",
+            description = "세계관을 전체 조회합니다." +
                     "\t\n 만료된 세계관은 조회에서 제외됩니다." +
                     "\t\n`order=recent` 인 경우 최신순을 반환하며 없는 경우에는 id asc 로 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "세계관 최신순 조회 성공"),
+            @ApiResponse(responseCode = "200", description = "세계관 전체 조회 성공"),
             @ApiResponse(responseCode = "400", description = "정렬 타입이 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
@@ -196,7 +196,8 @@ public class WorldController {
     @Operation(
             summary = "세계관 검색",
             description = "키워드로 `해시태그`와 `제목`을 기준으로 세계관 검색합니다." +
-                    "\t\n해시태그의 경우 완전 일치, 제목의 경우 단어가 포함되어 있으면 검색 결과에 포함됩니다."
+                    "\t\n해시태그의 경우 완전 일치, 제목의 경우 단어가 포함되어 있으면 검색 결과에 포함됩니다." +
+                    "\t\n`order=recent` 인 경우 최신순을 반환하며 없는 경우에는 id asc 로 반환합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "세계관 상세 정보 조회 성공"),
@@ -204,9 +205,12 @@ public class WorldController {
     })
     @GetMapping("/search")
     public ResponseEntity<ResponseDto<List<WorldHashtagsUserCountResponseDto>>> searchWorld(
-            @Parameter(description = "검색 키워드") @RequestParam("keyword") String keyword) {
+            @Parameter(description = "검색 키워드") @RequestParam("keyword") String keyword,
+            @Parameter(description = "세계관 정렬 기준") @RequestParam(value = "order", defaultValue = "id") String order
+    ) {
+        OrderType orderType = OrderType.fromString(order);
 
-        List<World> worlds= worldService.searchWorldByKeyword(keyword);
+        List<World> worlds= worldService.searchWorldByKeyword(keyword, orderType);
         List<WorldHashtagsUserCountResponseDto> dtoList = worlds.stream()
                 .map(WorldHashtagsUserCountResponseDto::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/cmc/repository/WorldRepository.java
+++ b/src/main/java/cmc/repository/WorldRepository.java
@@ -18,15 +18,32 @@ public interface WorldRepository extends JpaRepository<World, Long> {
 
     @Query(value = "SELECT w " +
             "FROM World w " +
-            "ORDER BY w.createdAt desc ")
-    List<World> getWorldsWithOrderRecent();
+            "WHERE w.worldEndDate >= CURRENT_DATE ")
+    List<World> getWorldsWithoutExpiredWorld();
 
     @Query(value = "SELECT w " +
+            "FROM World w " +
+            "WHERE w.worldEndDate >= CURRENT_DATE " +
+            "ORDER BY w.createdAt desc ")
+    List<World> getWorldsWithOrderRecentWithoutExpiredWorld();
+
+    @Query(value = "SELECT distinct w " +
             "FROM WorldHashtag wh " +
             "JOIN wh.world w " +
             "JOIN wh.hashtag h " +
-            "WHERE w.worldName LIKE CONCAT('%', :keyword, '%') " +
-            "OR h.hashtagName LIKE :keyword " +
+            "WHERE (w.worldName LIKE CONCAT('%', :keyword, '%') " +
+            "OR h.hashtagName LIKE :keyword) " +
+            "AND w.worldEndDate >= CURRENT_DATE " +
             "ORDER BY w.createdAt desc ")
-    List<World> searchWorldByWorldNameAndHashtagName(@Param("keyword") String keyword);
+    List<World> searchWorldByWorldNameAndHashtagNameWithOrderRecentWithoutExpiredWorld(@Param("keyword") String keyword);
+
+    @Query(value = "SELECT distinct w " +
+            "FROM WorldHashtag wh " +
+            "JOIN wh.world w " +
+            "JOIN wh.hashtag h " +
+            "WHERE (w.worldName LIKE CONCAT('%', :keyword, '%') " +
+            "OR h.hashtagName LIKE :keyword) " +
+            "AND w.worldEndDate >= CURRENT_DATE ")
+    List<World> searchWorldByWorldNameAndHashtagNameWithoutExpiredWorld(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/cmc/service/WorldService.java
+++ b/src/main/java/cmc/service/WorldService.java
@@ -76,11 +76,11 @@ public class WorldService {
     public List<World> getWorldsWithOrder(OrderType orderType) {
 
         if(orderType == OrderType.RECENT) {
-            return worldRepository.getWorldsWithOrderRecent();
+            return worldRepository.getWorldsWithOrderRecentWithoutExpiredWorld();
         }
 
         // recent가 아니라면 default로 id asc
-        return worldRepository.findAll();
+        return worldRepository.getWorldsWithoutExpiredWorld();
     }
 
     @Transactional
@@ -93,8 +93,13 @@ public class WorldService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.WORLD_NOT_FOUND));
     }
 
-    public List<World> searchWorldByKeyword(String keyword) {
-        return worldRepository.searchWorldByWorldNameAndHashtagName(keyword);
+    public List<World> searchWorldByKeyword(String keyword, OrderType orderType) {
+
+        if(orderType == OrderType.RECENT) {
+            return worldRepository.searchWorldByWorldNameAndHashtagNameWithOrderRecentWithoutExpiredWorld(keyword);
+        }
+
+        return worldRepository.searchWorldByWorldNameAndHashtagNameWithoutExpiredWorld(keyword);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 관련 이슈
closes #63 
## ✨ 작업 내용
- 세계관 검색 결과 조회 (만료된 세계관 제외)
- 세계관 최신순 조회  (만료된 세계관 제외)
- 세계관 조회 api 중에서 join 해서 가져온 경우 데이터 중복 문제 `distinct` 로 해결
## 📚 기타
