### PR TITLE
Fix/#123

### DIFF
--- a/src/main/java/cmc/controller/WorldController.java
+++ b/src/main/java/cmc/controller/WorldController.java
@@ -225,7 +225,7 @@ public class WorldController {
             @ApiResponse(responseCode = "400", description = "존재하지 않는 세계관입니다" +
                     "\t\n방장 유저가 아닌 유저는 접근 권한이 없습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PostMapping("/{worldId}/hashtags")
+    @PostMapping("/{worldId}/hashtags/save")
     public ResponseEntity<ResponseDto> updateNewWorldHashtags(
             Principal principal,
             @Parameter(description = "수정할 세계관 id", required = true) @PathVariable("worldId") Long worldId,

--- a/src/main/java/cmc/controller/WorldController.java
+++ b/src/main/java/cmc/controller/WorldController.java
@@ -249,7 +249,7 @@ public class WorldController {
             @ApiResponse(responseCode = "400", description = "존재하지 않는 세계관입니다" +
                     "\t\n 방장 유저가 아닌 유저는 접근 권한이 없습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @DeleteMapping("/{worldId}/hashtags")
+    @PostMapping("/{worldId}/hashtags/delete")
     public ResponseEntity<ResponseDto> updateDeletedWorldHashtags(
             Principal principal,
             @Parameter(description = "수정할 세계관 id", required = true) @PathVariable("worldId") Long worldId,

--- a/src/main/java/cmc/dto/request/UpdateWorldInfoRequestDto.java
+++ b/src/main/java/cmc/dto/request/UpdateWorldInfoRequestDto.java
@@ -5,24 +5,24 @@ import lombok.Getter;
 
 @Getter
 public class UpdateWorldInfoRequestDto {
-    @Schema(name = "세계관 이름", required = true)
+    @Schema(description = "세계관 이름", required = true)
     private String worldName;
 
-    @Schema(name = "세계관 인원 제한", required = true)
+    @Schema(description = "세계관 인원 제한", required = true)
     private Integer worldUserLimit;
 
-    @Schema(name = "세계관 시작 날짜", required = true)
+    @Schema(description = "세계관 시작 날짜", required = true)
     private String worldStartDate;
 
-    @Schema(name = "세계관 마감 날짜", required = true)
+    @Schema(description = "세계관 마감 날짜", required = true)
     private String worldEndDate;
 
-    @Schema(name = "세계관 공지", required = true)
+    @Schema(description = "세계관 공지", required = true)
     private String worldNotice;
 
-    @Schema(name = "세계관 비밀번호", required = true)
+    @Schema(description = "세계관 비밀번호", required = true)
     private String worldPassword;
 
-    @Schema(name = "세계관 방장 유저 id", required = true)
+    @Schema(description = "세계관 방장 유저 id", required = true)
     private Long worldHostUserId;
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #123 
## ✨ 작업 내용
해시태그 추가, 삭제 api url 삭제 및 http 메소드 변경
## 📚 기타
해시태그 삭제는 원래 DELETE 였으나 DELETE 는 request body를 넣을 수 없는 문제
request body가 아니라면 param으로 넣어줘야하는데 그럼 해시태그 삭제에 대한 요청을 하나당 하나씩 받을 수 밖에 없어서 
메소드를 post로 하고 여러개를 받는 방향으로 수정