### PR TITLE
[Fix] swagger 오류 기본 url 수정

### DIFF
--- a/src/main/java/cmc/config/OpenApiConfig.java
+++ b/src/main/java/cmc/config/OpenApiConfig.java
@@ -2,6 +2,7 @@ package cmc.config;
 
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -34,6 +35,7 @@ public class OpenApiConfig {
                 );
 
         return new OpenAPI()
+                .addServersItem(new Server().url("/"))
                 .components(components)
                 .info(info)
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName));


### PR DESCRIPTION
## 📌 관련 이슈
closes #168 
## ✨ 작업 내용
서버는 https 이지만 swagger는 http로 요청이 보내져 cors 발생
swagger config를 수정하여 현재 url 그대로 보내지게 한다.
## 📚 기타
